### PR TITLE
Allow for configuration of default git remote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+/*.egg-info

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ For the latest and greatest:
 
 ## Configuration
 
-Gruf expects a remote called "gerrit" to exist in your git config.  It must be the `ssh://` style in order for Gruf to parse it correctly.  For example:
+By default, Gruf expects a remote called "gerrit" to exist in your git config
+though the default remote name can be overridden by setting `remote` in Gruf's
+config.  It must be the `ssh://` style in order for Gruf to parse it
+correctly.  For example:
 
     [remote "gerrit"]
         url = ssh://someuser@gerrit.yourcompany.com:29418/repo/path

--- a/gruf/main.py
+++ b/gruf/main.py
@@ -91,7 +91,7 @@ def main():
         else config.get('cache', {}).get('lifetime'))
 
     g = gruf.gerrit.Gerrit(
-        remote=args.remote,
+        remote=args.remote or config.get('remote'),
         querymap=config.get('querymap'),
         cache_lifetime=cache_lifetime)
     LOG.debug('remote %s', g.remote)


### PR DESCRIPTION
My typical workflow involves using Gerrit as origin (since that's where we host code as well as review), and I got tired of using the `-r` flag.